### PR TITLE
Implement python version text matrix; move black check to PR only

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,17 +1,12 @@
-name: CI
+name: black check
 
 on:
-  push:
-    branches:
-      - "**"
-    paths:
-      - 'undate/**'
-      - 'tests/**'
   pull_request:
 
 jobs:
-  qa:
+  python-unit:
     runs-on: ubuntu-latest
+
     defaults:
       run:
         working-directory: .
@@ -29,5 +24,3 @@ jobs:
         if: steps.python-cache.outputs.cache-hit != 'true'
       - name: Run black
         run: black undate --check --diff
-      - name: Run unit tests
-        run: pytest

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,10 +1,10 @@
-name: black check
+name: style check
 
 on:
   pull_request:
 
 jobs:
-  python-unit:
+  check:
     runs-on: ubuntu-latest
 
     defaults:

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -1,0 +1,34 @@
+name: unit tests
+
+on:
+  push:
+    branches:
+      - "**"
+    paths:
+      - 'undate/**'
+      - 'tests/**'
+  pull_request:
+
+jobs:
+  python-unit:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python: [3.8, 3.9, 3.10, 3.11]
+    defaults:
+      run:
+        working-directory: .
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python }}
+          cache: 'pip'
+          cache-dependency-path: '**/setup.py'
+      - name: Install package with dependencies
+        run: pip install -e ".[dev]"
+        if: steps.python-cache.outputs.cache-hit != 'true'
+      - name: Run unit tests
+        run: pytest

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [3.8, 3.9, 3.10, 3.11]
+        python: ["3.8", "3.9", "3.10", "3.11"]
     defaults:
       run:
         working-directory: .

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 Repository for the DHTech 2022 Hackathon
 
+[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+[![unit tests](https://github.com/dh-tech/hackathon-2022/actions/workflows/unit_tests.yml/badge.svg)](https://github.com/dh-tech/hackathon-2022/actions/workflows/unit_tests.yml)
+[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 
 ## License
 

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,8 @@ setup(
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Topic :: Software Development :: Libraries :: Python Modules",
         "Topic :: Utilities",
         "Typing :: Typed",


### PR DESCRIPTION
ref #13

- split existing CI workflow to unit_tests and check
- implemented matrix build for unit test workflow
- configure check workflow to only run on PRs 

questions:
- should we put supported versions of python in the readme? or wait until we can pull from pypi as a badge?
- when we switch to new setup style config in #28 could we specify python versions in one place for both setup/pypi and the matrix build?